### PR TITLE
Add CalendarUtil tests

### DIFF
--- a/calendar_date_range_picker/build.gradle
+++ b/calendar_date_range_picker/build.gradle
@@ -33,12 +33,14 @@ android {
 }
 
 dependencies {
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.5.0'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.3.0'
-    testImplementation 'junit:junit:4.+'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'com.google.truth:truth:1.1.3'
+
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/calendar_date_range_picker/src/main/java/dev/joshhalvorson/calendar_date_range_picker/calendar/CalendarUtils.kt
+++ b/calendar_date_range_picker/src/main/java/dev/joshhalvorson/calendar_date_range_picker/calendar/CalendarUtils.kt
@@ -2,18 +2,36 @@ package dev.joshhalvorson.calendar_date_range_picker.calendar
 
 import java.time.Year
 
-// functions to determine the day of the week any given date is
-object CalendarUtils {
-    fun getDayOfWeekOfDate(year: Int, month: Int, date: Int): Int {
+/** Utility class */
+internal object CalendarUtils {
+    private const val JANUARY = "January"
+    private const val FEBRUARY =  "February"
+    private const val MARCH =  "March"
+    private const val APRIL =  "April"
+    private const val MAY =  "May"
+    private const val JUNE =  "June"
+    private const val JULY =  "July"
+    private const val AUGUST =  "August"
+    private const val SEPTEMBER =  "September"
+    private const val OCTOBER =  "October"
+    private const val NOVEMBER =  "November"
+    private const val DECEMBER =  "December"
+
+    /**
+     * Determines the day of the week for the given date.
+     *
+     * @return an index representing the day of the week where 1 is monday, 2 tuesday, etc.
+     */
+    internal fun getDayOfWeekOfDate(year: Int, month: Int, date: Int): Int {
         return (getYearCode(year) + getMonthCode(month) + getCenturyCode(year) + date - (if (isLeapYear(year, month)) 1 else 0)) % 7
     }
 
-    fun getYearCode(year: Int): Int {
+    private fun getYearCode(year: Int): Int {
         val lastTwoDigits = year.toString().takeLast(2).toInt()
         return (lastTwoDigits + (lastTwoDigits.div(4))) % 7
     }
 
-    fun getMonthCode(month: Int): Int {
+    private fun getMonthCode(month: Int): Int {
         return when (month) {
             0 -> 0
             1 -> 3
@@ -31,14 +49,14 @@ object CalendarUtils {
         }
     }
 
-    fun getCenturyCode(year: Int): Int {
+    private fun getCenturyCode(year: Int): Int {
         return when (year) {
             in 2000..2099 -> 6
             else -> -1
         }
     }
 
-    fun isLeapYear(year: Int, month: Int): Boolean {
+    internal fun isLeapYear(year: Int, month: Int): Boolean {
         val leapMonth = when (month) {
             0 -> true
             1 -> true
@@ -54,35 +72,52 @@ object CalendarUtils {
         return true
     }
 
+    internal fun isLeapYear(year: Int): Boolean {
+        return when {
+            year % 4 != 0 -> {
+                false
+            }
+            year % 100 != 0 -> {
+                true
+            }
+            year % 400 != 0 -> {
+                false
+            }
+            else -> {
+                true
+            }
+        }
+    }
+
     object Constants {
         val STRING_MONTHS_TO_INT_MONTHS = mapOf<String, Int>(
-            "January" to 0,
-            "February" to 1,
-            "March" to 2,
-            "April" to 3,
-            "May" to 4,
-            "June" to 5,
-            "July" to 6,
-            "August" to 7,
-            "September" to 8,
-            "October" to 9,
-            "November" to 10,
-            "December" to 11
+            JANUARY to 0,
+            FEBRUARY to 1,
+            MARCH to 2,
+            APRIL to 3,
+            MAY to 4,
+            JUNE to 5,
+            JULY to 6,
+            AUGUST to 7,
+            SEPTEMBER to 8,
+            OCTOBER to 9,
+            NOVEMBER to 10,
+            DECEMBER to 11
         )
 
         val INT_MONTHS_TO_STRING_MONTHS = mapOf<Int, String>(
-            0 to "January",
-            1 to "February",
-            2 to "March",
-            3 to "April",
-            4 to "May",
-            5 to "June",
-            6 to "July",
-            7 to "August",
-            8 to "September",
-            9 to "October",
-            10 to "November",
-            11 to "December",
+            0 to JANUARY,
+            1 to FEBRUARY,
+            2 to MARCH,
+            3 to APRIL,
+            4 to MAY,
+            5 to JUNE,
+            6 to JULY,
+            7 to AUGUST,
+            8 to SEPTEMBER,
+            9 to OCTOBER,
+            10 to NOVEMBER,
+            11 to DECEMBER,
         )
 
         val daysInMonth = arrayOf(

--- a/calendar_date_range_picker/src/test/java/dev/joshhalvorson/calendar_date_range_picker/calendar/CalendarUtilsTest.kt
+++ b/calendar_date_range_picker/src/test/java/dev/joshhalvorson/calendar_date_range_picker/calendar/CalendarUtilsTest.kt
@@ -1,0 +1,85 @@
+package dev.joshhalvorson.calendar_date_range_picker.calendar
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+
+internal class CalendarUtilsTest {
+
+    private val mondayCode = 1
+    private val tuesdayCode = 2
+    private val wednesdayCode = 3
+    private val thursdayCode = 4
+    private val fridayCode = 5
+    private val saturdayCode = 6
+    private val sundayCode = 7
+
+    @Before
+    fun setUp() {
+    }
+
+    @After
+    fun tearDown() {
+    }
+
+    @Test
+    fun getDayOfWeekOfDateShouldSuccess() {
+        val year = 2021
+        val august = 7 // 0-based index
+        val september = 8 // 0-based index
+
+        // yyyy-mm-dd: 2021-08-30 is monday
+        assertThat(CalendarUtils.getDayOfWeekOfDate(year, august, 30)).isEqualTo(mondayCode)
+
+        // yyyy-mm-dd: 2021-08-31 is tuesday
+        assertThat(CalendarUtils.getDayOfWeekOfDate(year, august, 31)).isEqualTo(tuesdayCode)
+
+        // yyyy-mm-dd: 2021-09-01 is wednesday
+        assertThat(CalendarUtils.getDayOfWeekOfDate(year, september, 1)).isEqualTo(wednesdayCode)
+
+        // yyyy-mm-dd: 2021-09-02 is thursday
+        assertThat(CalendarUtils.getDayOfWeekOfDate(year, september, 2)).isEqualTo(thursdayCode)
+
+        // yyyy-mm-dd: 2021-09-02 is friday
+        assertThat(CalendarUtils.getDayOfWeekOfDate(year, september, 3)).isEqualTo(fridayCode)
+    }
+
+    @Test
+    fun getDayOfWeekOfDateShouldSuccessButIsFailing() {
+        val year = 2021
+        val august = 7 // 0-based index
+
+        // this test if failing because CalendarUtils.isLeapYear(year, month) is buggy
+        // see comments in test: isLeapYearShouldSuccessButIsFailing
+
+        // yyyy-mm-dd: 2020-02-31 is friday
+        assertThat(CalendarUtils.getDayOfWeekOfDate(year, august, 31)).isEqualTo(fridayCode)
+    }
+
+    @Test
+    fun isLeapYearShouldSuccessButIsFailing() {
+        // this test was added as a proof that CalendarUtils.isLeapYear(year, month) is buggy
+        // as an alternative I added CalendarUtils.isLeapYear(year).
+        // If PR is OK we will migrate the code to use the new isLeapYear and remove this test.
+        val leapYear = 2020
+        val month = 2
+
+        assertThat(CalendarUtils.isLeapYear(leapYear, month)).isTrue()
+    }
+
+    @Test
+    fun isLeapYearSuccessOnAllMonths() {
+        val leapYear = 2020
+
+        assertThat(CalendarUtils.isLeapYear(leapYear)).isTrue()
+    }
+
+    @Test
+    fun isLeapYearFailureOnAllMonths() {
+        val leapYear = 2021
+
+        assertThat(CalendarUtils.isLeapYear(leapYear)).isFalse()
+    }
+}


### PR DESCRIPTION
I added 2 failing tests:
  - `isLeapYearShouldSuccessButIsFailing`
  - `getDayOfWeekOfDateShouldSuccessButIsFailing`
  
The goal is to prove that `CalendarUtils.isLeapYear(year, month)` is buggy. It does not return the correct result all the time (see tests).

The test in `getDayOfWeekOfDateShouldSuccessButIsFailing` is failing since it's using `CalendarUtils.isLeapYear(year, month)` internally.

I wrote another `isLeapYear` method (different signature) and added tests for that. Next step is to migrate the code from old method to the new one if the PR is valid of course.

related to issue : #5 